### PR TITLE
Grave Abandoning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,8 +116,8 @@
             <url>https://repo.glaremasters.me/repository/bloodshot</url>
         </repository>
         <repository>
-            <id>jeff-media-repo</id>
-            <url>https://repo.jeff-media.de/maven2/</url>
+            <id>jeff-media-public</id>
+            <url>https://hub.jeff-media.com/nexus/repository/jeff-media-public/</url>
         </repository>
         <repository>
             <id>enginehub</id>
@@ -193,8 +193,7 @@
         <dependency>
             <groupId>com.github.Ste3et</groupId>
             <artifactId>FurnitureLib</artifactId>
-            <version>22fb4086de</version>
-            <scope>provided</scope>
+            <version>v2.2.8</version>
         </dependency>
         <dependency>
             <groupId>com.github.LoneDev6</groupId>
@@ -211,7 +210,7 @@
         <dependency>
             <groupId>de.jeff_media</groupId>
             <artifactId>ChestSortAPI</artifactId>
-            <version>11.0.0-SNAPSHOT</version>
+            <version>12.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/ranull/graves/integration/FurnitureLib.java
+++ b/src/main/java/com/ranull/graves/integration/FurnitureLib.java
@@ -82,8 +82,8 @@ public final class FurnitureLib extends FurniturePlugin {
             if (project != null && project.haveModelSchematic()) {
                 ObjectID objectID = new ObjectID(project.getName(), project.getPlugin().getName(), location);
 
-                location.setYaw(furnitureLib.getLocationUtil().FaceToYaw(LocationUtil.yawToFace(grave.getYaw())
-                        .getOppositeFace()));
+//                location.setYaw(furnitureLib.getLocationUtil().FaceToYaw(LocationUtil.yawToFace(grave.getYaw())
+//                        .getOppositeFace()));
                 furnitureLib.spawn(project, objectID);
                 objectID.setUUID(UUID.randomUUID());
                 objectID.getBlockList().stream()

--- a/src/main/java/com/ranull/graves/inventory/Grave.java
+++ b/src/main/java/com/ranull/graves/inventory/Grave.java
@@ -26,6 +26,7 @@ public class Grave implements InventoryHolder {
     private Inventory inventory;
     private int experience;
     private boolean protection;
+    private boolean abandoned;
     private long timeAlive;
     private long timeCreation;
     private long timeProtection;
@@ -152,6 +153,12 @@ public class Grave implements InventoryHolder {
     public void setProtection(boolean protection) {
         this.protection = protection;
     }
+
+    public boolean isAbandoned() {
+        return abandoned;
+    }
+
+    public void setAbandoned(boolean abandoned) { this.abandoned = abandoned; }
 
     public long getTimeAlive() {
         return timeAlive;

--- a/src/main/java/com/ranull/graves/listener/EntityDeathListener.java
+++ b/src/main/java/com/ranull/graves/listener/EntityDeathListener.java
@@ -316,7 +316,12 @@ public class EntityDeathListener implements Listener {
 
                     grave.setKillerUUID(entityDamageByEntityEvent.getDamager().getUniqueId());
                     grave.setKillerType(entityDamageByEntityEvent.getDamager().getType());
-                    grave.setKillerName(plugin.getEntityManager().getEntityName(entityDamageByEntityEvent.getDamager()));
+                    if (plugin.getEntityManager().getEntityName(entityDamageByEntityEvent.getDamager()).contains("entity.mineinabyss.")) {
+                        grave.setKillerName(StringUtil.format(plugin.getEntityManager().getEntityName(entityDamageByEntityEvent
+                                .getDamager()).replace("entity.mineinabyss.", "")));
+                    } else {
+                        grave.setKillerName(plugin.getEntityManager().getEntityName(entityDamageByEntityEvent.getDamager()));
+                    }
                 } else {
                     grave.setKillerUUID(null);
                     grave.setKillerType(null);

--- a/src/main/java/com/ranull/graves/listener/EntityDeathListener.java
+++ b/src/main/java/com/ranull/graves/listener/EntityDeathListener.java
@@ -325,7 +325,7 @@ public class EntityDeathListener implements Listener {
                 } else {
                     grave.setKillerUUID(null);
                     grave.setKillerType(null);
-                    grave.setKillerName(plugin.getGraveManager().getDamageCause(entityDamageEvent.getCause(), grave));
+                    grave.setKillerName("Falling"); // Custom might be more than falldamage, but since BoneHurt
                 }
             }
 

--- a/src/main/java/com/ranull/graves/manager/DataManager.java
+++ b/src/main/java/com/ranull/graves/manager/DataManager.java
@@ -643,7 +643,7 @@ public final class DataManager {
 
         plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
             executeUpdate("INSERT INTO grave (uuid, owner_type, owner_name, owner_uuid, owner_texture, killer_type, killer_name,"
-                    + " killer_uuid, location_death, yaw, pitch, inventory, experience, protection, time_alive, time_protection,"
+                    + " killer_uuid, location_death, yaw, pitch, inventory, experience, protection, abandoned, time_alive, time_protection,"
                     + " time_creation, permissions) VALUES (" + uuid + ", " + ownerType + ", "
                     + ownerName + ", " + ownerUUID + ", " + ownerTexture + ", " + killerType + ", " + killerName + ", " + killerUUID
                     + ", " + locationDeath + ", " + yaw + ", " + pitch + ", " + inventory + ", " + experience + ", " + protection + ", " + abandoned + ", "

--- a/src/main/java/com/ranull/graves/manager/DataManager.java
+++ b/src/main/java/com/ranull/graves/manager/DataManager.java
@@ -177,6 +177,7 @@ public final class DataManager {
                 "inventory TEXT,\n" +
                 "experience INT(16),\n" +
                 "protection INT(1),\n" +
+                "abandoned INT(0),\n" +
                 "time_alive INT(16),\n" +
                 "time_protection INT(11),\n" +
                 "time_creation INT(11),\n" +
@@ -238,6 +239,10 @@ public final class DataManager {
 
         if (!columnList.contains("protection")) {
             executeUpdate("ALTER TABLE " + name + " ADD COLUMN protection INT(1);");
+        }
+
+        if (!columnList.contains("abandoned")) {
+            executeUpdate("ALTER TABLE " + name + " ADD COLUMN abandoned INT(0);");
         }
 
         if (!columnList.contains("time_alive")) {
@@ -630,6 +635,7 @@ public final class DataManager {
         String permissions = grave.getPermissionList() != null && !grave.getPermissionList().isEmpty()
                 ? "'" + StringUtils.join(grave.getPermissionList(), "|") + "'" : "NULL";
         int protection = grave.getProtection() ? 1 : 0;
+        int abandoned = grave.isAbandoned() ? 1 : 0;
         int experience = grave.getExperience();
         long timeAlive = grave.getTimeAlive();
         long timeProtection = grave.getTimeProtection();
@@ -640,7 +646,7 @@ public final class DataManager {
                     + " killer_uuid, location_death, yaw, pitch, inventory, experience, protection, time_alive, time_protection,"
                     + " time_creation, permissions) VALUES (" + uuid + ", " + ownerType + ", "
                     + ownerName + ", " + ownerUUID + ", " + ownerTexture + ", " + killerType + ", " + killerName + ", " + killerUUID
-                    + ", " + locationDeath + ", " + yaw + ", " + pitch + ", " + inventory + ", " + experience + ", " + protection + ", "
+                    + ", " + locationDeath + ", " + yaw + ", " + pitch + ", " + inventory + ", " + experience + ", " + protection + ", " + abandoned + ", "
                     + timeAlive + ", " + timeProtection + ", " + timeCreation + ", " + permissions + ");");
         });
     }
@@ -684,6 +690,7 @@ public final class DataManager {
             grave.setPitch(resultSet.getFloat("pitch"));
             grave.setExperience(resultSet.getInt("experience"));
             grave.setProtection(resultSet.getInt("protection") == 1);
+            grave.setAbandoned(resultSet.getInt("abandoned") == 1);
             grave.setTimeAlive(resultSet.getLong("time_alive"));
             grave.setTimeProtection(resultSet.getLong("time_protection"));
             grave.setTimeCreation(resultSet.getLong("time_creation"));

--- a/src/main/java/com/ranull/graves/manager/GraveManager.java
+++ b/src/main/java/com/ranull/graves/manager/GraveManager.java
@@ -208,6 +208,7 @@ public final class GraveManager {
         grave.setAbandoned(true);
         grave.setTimeProtection(0);
         grave.setOwnerUUID(UUID.randomUUID()); // Since uuid cant be null, this seems like the best solution...
+        plugin.getDataManager().updateGrave(grave, "owner_uuid", String.valueOf(grave.getOwnerUUID()));
         plugin.getDataManager().updateGrave(grave, "abandoned", String.valueOf(grave.isAbandoned() ? 1 : 0));
 
     }

--- a/src/main/java/com/ranull/graves/manager/GraveManager.java
+++ b/src/main/java/com/ranull/graves/manager/GraveManager.java
@@ -204,6 +204,14 @@ public final class GraveManager {
         plugin.getDataManager().updateGrave(grave, "protection", String.valueOf(grave.getProtection() ? 1 : 0));
     }
 
+    public void abandonGrave(Grave grave) {
+        grave.setAbandoned(true);
+        grave.setTimeProtection(0);
+        grave.setOwnerUUID(UUID.randomUUID()); // Since uuid cant be null, this seems like the best solution...
+        plugin.getDataManager().updateGrave(grave, "abandoned", String.valueOf(grave.isAbandoned() ? 1 : 0));
+
+    }
+
     public void graveParticle(Location location, Grave grave) {
         if (location.getWorld() != null && plugin.getConfig("particle.enabled", grave)
                 .getBoolean("particle.enabled")) {

--- a/src/main/java/com/ranull/graves/manager/PlayerManager.java
+++ b/src/main/java/com/ranull/graves/manager/PlayerManager.java
@@ -331,6 +331,14 @@ public final class PlayerManager {
 
                 break;
             }
+            case "abandoned": {
+                plugin.getGraveManager().abandonGrave(grave);
+                plugin.getPlayerManager().playPlayerSound("sound.abandoned", player, grave);
+                plugin.getPlayerManager().sendMessage("message.abandoned", player, player.getLocation(), grave);
+                player.closeInventory(); // Close Grave GUI
+
+                break;
+            }
             case "distance": {
                 Location location = plugin.getGraveManager().getGraveLocation(player.getLocation(), grave);
 

--- a/src/main/java/com/ranull/graves/util/StringUtil.java
+++ b/src/main/java/com/ranull/graves/util/StringUtil.java
@@ -97,6 +97,7 @@ public final class StringUtil {
                                     .getString("protection.state.protected", "Protected") : plugin
                                     .getConfig("protection.state.unprotected", grave)
                                     .getString("protection.state.unprotected", "Unprotected"))
+                    .replace("%state_abandoned%", String.valueOf(grave.isAbandoned()))
                     .replace("%item%", String.valueOf(grave.getItemAmount()));
             if (grave.getExperience() > 0) {
                 string = string.replace("%level%", String.valueOf(ExperienceUtil

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -581,6 +581,7 @@ settings:
         distance-virtual: "You are too far away to virtually open this grave."
         permission-denied: "Permission denied."
         protection: "This grave is protected for %time_protection_remaining_formatted%."
+        abandoned: "You abandoned your grave."
         region-create-deny: "A grave was not created because grave creation is disabled in this region."
         region-teleport-deny: "Grave teleportation is disabled in this region."
         death-reason: # https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html
@@ -634,6 +635,7 @@ settings:
         menu-open: ENTITY_CHICKEN_EGG
         protection: BLOCK_CHEST_LOCKED
         protection-change: ENTITY_DONKEY_CHEST
+        abandoned: ENTITY_LLAMA_DEATH
 
       ##########
       # Effect #

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -635,7 +635,7 @@ settings:
         menu-open: ENTITY_CHICKEN_EGG
         protection: BLOCK_CHEST_LOCKED
         protection-change: ENTITY_DONKEY_CHEST
-        abandoned: ENTITY_LLAMA_DEATH
+        abandoned: ENTITY_ZOMBIE_BREAK_WOODEN_DOOR
 
       ##########
       # Effect #


### PR DESCRIPTION
Closes #3 #2 

Still getting errors with SQL as it isnt registered properly.
After a restart the grave is also removed, probably why tho

```
[13:20:37 WARN]: org.sqlite.SQLiteException: [SQLITE_ERROR] SQL error or missing database (19 values for 18 columns)
[13:20:37 WARN]:        at org.sqlite.core.DB.newSQLException(DB.java:1012)
[13:20:37 WARN]:        at org.sqlite.core.DB.newSQLException(DB.java:1024)
[13:20:37 WARN]:        at org.sqlite.core.DB.throwex(DB.java:989)
[13:20:37 WARN]:        at org.sqlite.core.NativeDB._exec_utf8(Native Method)
[13:20:37 WARN]:        at org.sqlite.core.NativeDB._exec(NativeDB.java:94)
[13:20:37 WARN]:        at org.sqlite.jdbc3.JDBC3Statement.executeUpdate(JDBC3Statement.java:102)
[13:20:37 WARN]:        at Graves-4.4.jar//com.ranull.graves.manager.DataManager.executeUpdate(DataManager.java:758)
[13:20:37 WARN]:        at Graves-4.4.jar//com.ranull.graves.manager.DataManager.lambda$addGrave$11(DataManager.java:645)
[13:20:37 WARN]:        at org.bukkit.craftbukkit.v1_17_R1.scheduler.CraftTask.run(CraftTask.java:101)
[13:20:37 WARN]:        at org.bukkit.craftbukkit.v1_17_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57)
[13:20:37 WARN]:        at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22)
[13:20:37 WARN]:        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
[13:20:37 WARN]:        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
[13:20:37 WARN]:        at java.base/java.lang.Thread.run(Thread.java:831)
```